### PR TITLE
Polish harvesting overlay

### DIFF
--- a/rules/sharedrules.yaml
+++ b/rules/sharedrules.yaml
@@ -146,7 +146,7 @@ HARV:
 	Explodes:
 		Weapon: TiberiumExplosion
 	WithHarvestOverlay:
-		Offset: 1500,0,0
+		LocalOffset: 768,0,0
 		Palette: effect
 	SelectionDecorations:
 	Capturable:

--- a/sequences/scrseq.yaml
+++ b/sequences/scrseq.yaml
@@ -385,24 +385,6 @@ drache.falling:
 	idle: drache
 		Start: 1
 
-scrharv:
-	Inherits: ^EmpOverlay
-	idle:
-		Facings: -32
-		ShadowStart: 32
-	move:
-		Facings: -32
-		ShadowStart: 32
-	dock:
-		Facings: -32
-		ShadowStart: 32
-	dock-loop:
-		Facings: -32
-		ShadowStart: 32
-	harvest: harvestr
-		Length: *
-	icon: scrharvicon
-
 scrscorpion:
 	Inherits: ^EmpOverlay
 	stand:

--- a/sequences/sharedseq.yaml
+++ b/sequences/sharedseq.yaml
@@ -242,8 +242,8 @@ mcv.gdi:
 	harvest: harvestr
 		Length: *
 		ZRamp: 1
-		Offset: 0, 0, 6
-		ZOffset: -500
+		Offset: 0,0,0
+		ZOffset: -512
 	icon: sidebar-gdi|harvicon
 	dock:
 		Length: 1
@@ -287,6 +287,22 @@ cabharv:
 		Facings: 8
 		ShadowStart: 86
 	icon: cabharvicon
+
+scrharv:
+	Inherits: ^Harvester
+	idle:
+		Facings: -32
+		ShadowStart: 32
+	move:
+		Facings: -32
+		ShadowStart: 32
+	dock:
+		Facings: -32
+		ShadowStart: 32
+	dock-loop:
+		Facings: -32
+		ShadowStart: 32
+	icon: scrharvicon
 
 lpst.gdi:
 	Inherits: ^EmpOverlay


### PR DESCRIPTION
This will make the harvesting overlay appear at the front of the harvester instead of below its body. See also commits.