### PR TITLE
Remove TemporaryOwnerManager 

### DIFF
--- a/mod.yaml
+++ b/mod.yaml
@@ -12,7 +12,6 @@ Packages:
 	.
 	./mods/common: common
 	./mods/as: as
-	$d2k: d2k
 	$sp: sp
 	$ts: ts
 # Tiberian Sun
@@ -183,7 +182,6 @@ Chrome:
 Assemblies:
 	common|OpenRA.Mods.Common.dll
 	common|OpenRA.Mods.Cnc.dll
-	d2k|OpenRA.Mods.D2k.dll
 	as|OpenRA.Mods.AS.dll
 
 ChromeLayout:

--- a/rules/defaults.yaml
+++ b/rules/defaults.yaml
@@ -1106,7 +1106,6 @@
 	Inherits@5: ^5CellVision
 	DrawLineToTarget:
 	WithTextControlGroupDecoration:
-	TemporaryOwnerManager:
 	GivesExperience:
 		PlayerExperienceModifier: 1
 	Chronoshiftable:
@@ -1482,7 +1481,6 @@
 	Inherits@3: ^VehicleShape
 	Inherits@4: ^5CellVision
 	DrawLineToTarget:
-	TemporaryOwnerManager:
 	WithTextControlGroupDecoration:
 	GivesExperience:
 		PlayerExperienceModifier: 1

--- a/rules/infantry.yaml
+++ b/rules/infantry.yaml
@@ -454,7 +454,6 @@ BHS:
 		CloakDelay: 50
 		IsPlayerPalette: true
 		UncloakOn: Attack
-	-TemporaryOwnerManager:
 	RenderSprites:
 	-DamagedByTerrain:
 
@@ -735,7 +734,6 @@ PSYKER:
 		Speed: 70
 	Targetable@MindControlImmunity:
 		TargetTypes: MindControlInmune
-	-TemporaryOwnerManager:
 	Armament@PRIMARY:
 		Weapon: PsykerRay
 		Name: OnFoot
@@ -1432,7 +1430,6 @@ CYC2:
 		Speed: 65
 	Health:
 		HP: 70000
-	-TemporaryOwnerManager:
 	Targetable@MindControlImmunity:
 		TargetTypes: MindControlInmune
 	Targetable@MCImmune:

--- a/rules/sharedrules.yaml
+++ b/rules/sharedrules.yaml
@@ -137,7 +137,6 @@ HARV:
 			Veins: 100
 	Health:
 		HP: 50000
-	-TemporaryOwnerManager:
 	Targetable@MindControl:
 		TargetTypes: MindControlInmune
 	Armor:

--- a/rules/vehicles.yaml
+++ b/rules/vehicles.yaml
@@ -379,7 +379,6 @@ HMEC:
 		MuzzleSequence: muzzle
 	Targetable@MindControl:
 		TargetTypes: MindControlInmune
-	-TemporaryOwnerManager:
 	-WithVoxelBody:
 	Turreted:
 		Offset: -500,0,0

--- a/weapons/scrweapons.yaml
+++ b/weapons/scrweapons.yaml
@@ -975,6 +975,7 @@ HealScrin:
 		# ValidTargets: Mothership
 		# DamageTypes: Prone50Percent, TriggerProne, SmallExplosionDeath
 
+# ChangeOwner can no longer be used since we removed all d2k dependencies!
 # CouncilSteal:
 	# ReloadDelay: 150
 	# Range: 6c0
@@ -993,7 +994,7 @@ HealScrin:
 		# Versus:
 			# ConcreteArmor: 30
 		# DamageTypes: Prone70Percent, TriggerProne, BulletDeath
-	# Warhead@4OwnerChange: ChangeOwner
+	# Warhead@4OwnerChange: ChangeOwner 
 		# Range: 1c512
 		# Duration: 75
 		# InvalidTargets: C4, MindControlInmune


### PR DESCRIPTION
The trait is the only leftover of D2K code and can be removed without any effects. I searched all files and it is only used for a disabled scrin weapon and activated for some defaults/deactivated for certain actors. Its removal is necessary to exclude all D2K mod data from the release build, which I have tested to build, install and start the game without errors.